### PR TITLE
support rspec its, fix tests and threads

### DIFF
--- a/lib/streak.rb
+++ b/lib/streak.rb
@@ -15,6 +15,7 @@ require "streak/stage"
 require "streak/user"
 require "streak/search"
 require "streak/file"
+require "streak/thread"
 
 module Streak
   @api_base = "https://www.streak.com/api/v1"

--- a/lib/streak/thread.rb
+++ b/lib/streak/thread.rb
@@ -1,0 +1,14 @@
+module Streak
+  class Thread < StreakObject
+    def self.all(box_key)
+      path = "/boxes/#{box_key}/threads"
+      res = Streak.request(:get, path)
+      convert_to_streak_object(res, Thread)
+    end
+
+    def self.find(key)
+      res = Streak.request(:get, "/threads/#{key}")
+      convert_to_streak_object(res, Thread)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 require 'streak'
+require 'rspec/its'
 
 #monkeypatch request methods
 module Streak

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -165,3 +165,30 @@ def test_user(params={})
     "key" => "agptYWlsZm9vZ2FlciYLEgxPcmdhbml6YXRpb24iCnN0cmVhay5jb20MCxIEVXNlchgBDA"
   }.merge(params)
 end
+
+def test_thread(params={})
+  {
+    "creatorKey": "agptYWlsZm9vZ2FlciYLEgxPcmdhbml6YXRpb24iCnN0cmVhay5jb20MCxIEVXNlchgBDA",
+    "boxKey": "agptYWlsZm9vZ2FlciYLEgxPcmdhbml6YXRpb24iCnN0cmVhay5jb20MCxIEQ2FzZRgJDA",
+    "pipelineKey": "agptYWlsZm9vZ2FlcioLEgxPcmdhbml6YXRpb24iCnN0cmVhay5jb20MCxIIV29ya2Zsb3cYBQw",
+    "creationTimestamp": 1367889076605,
+    "lastUpdatedTimestamp": 1367889076605,
+    "lastEmailTimestamp": 1367886197000,
+    "subject": "Re: Some email subject line",
+    "names": [
+      "Adam Smith",
+      "Betty Smith",
+      "Carl Jones"
+    ],
+    "emailAddresses": [
+      "asmith@example.com",
+      "bsmith@example.com",
+      "carl.jones@gmail.com"
+    ],
+    "threadGmailId": "13e7c4bcce4c3693",
+    "fileKeys": [],
+    "files": [],
+    "gmailThreadKey": "agptYWlsZm9vZ2Flci0LEgxPcmdhbml6YXRpb24iCnN0cmVhay5jb20MCxILR21haWxUaHJlYWQYKQw",
+    "key": "agptYWlsZm9vZ2Flci0LEgxPcmdhbml6YXRpb24iCnN0cmVhay5jb20MCxILR21haWxUaHJlYWQYKQw"
+  }.merge(params)
+end

--- a/spec/streak/thread_spec.rb
+++ b/spec/streak/thread_spec.rb
@@ -1,0 +1,24 @@
+describe Streak::Thread do
+  let!(:api) { Streak.mock_rest_client = double('RestClient') }
+  let(:thread) { test_thread }
+
+  describe ".all" do
+    it "should call the api" do
+      api.should_receive(:get).
+        with(Streak.api_url("/boxes/box_key_1/threads"), nil, nil).
+        and_return(test_response([thread]))
+
+      Streak::Thread.all("box_key_1")
+    end
+  end
+
+  describe ".find" do
+    it "should call the api" do
+      api.should_receive(:get).
+        with(Streak.api_url("/threads/thread_key_1"), nil, nil).
+        and_return(test_response(thread))
+
+      Streak::Thread.find("thread_key_1")
+    end
+  end
+end

--- a/streak-ruby.gemspec
+++ b/streak-ruby.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec-its"
 end


### PR DESCRIPTION
Rspec extracted its into its own gem. Adding it as a dev dependency and requiring it in the spec_helper was easy enough and made all the tests pass.